### PR TITLE
Da rat update. (And bugfixes!)

### DIFF
--- a/_maps/map_files/temperance/dungeons.dmm
+++ b/_maps/map_files/temperance/dungeons.dmm
@@ -196,6 +196,7 @@
 	pixel_x = 1;
 	pixel_y = -4
 	},
+/obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/rogue/grime,
 /area/rogue/under/cave/warmachine)
 "cR" = (
@@ -3032,6 +3033,11 @@
 /obj/effect/decal/loader,
 /turf/open/floor/rogue/warmetal,
 /area/rogue/under/cave/dungeon1)
+"Xl" = (
+/obj/effect/decal/cleanable/dirt/grime,
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/grime,
+/area/rogue/under/cave/warmachine)
 "Xp" = (
 /obj/structure/closet/crate/drawer/filing/alt3,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
@@ -34109,7 +34115,7 @@ Le
 dt
 CC
 Le
-Le
+Xl
 Le
 Ze
 IC

--- a/_maps/map_files/temperance/kingsrow.dmm
+++ b/_maps/map_files/temperance/kingsrow.dmm
@@ -1314,6 +1314,10 @@
 /obj/structure/mineral_door/wood/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors)
+"hE" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors)
 "hF" = (
 /obj/effect/mine/explosive,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -1573,6 +1577,10 @@
 "jO" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jR" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/beach/forest/south)
 "jV" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -3754,6 +3762,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
+"zg" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest/south)
 "zk" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -4176,6 +4188,10 @@
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
+"BY" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "Ca" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/fluff/railing/border/west,
@@ -7381,6 +7397,10 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/town)
+"WZ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/beach/forest/south)
 "Xa" = (
 /obj/structure/fluff/pillow/magenta{
 	pixel_x = 2;
@@ -16851,7 +16871,7 @@ md
 TY
 TY
 TY
-TY
+BY
 aX
 TY
 aX
@@ -62302,7 +62322,7 @@ xP
 Hf
 tn
 tn
-Hf
+WZ
 Hf
 Hf
 Hf
@@ -65061,7 +65081,7 @@ xP
 xP
 Hf
 Hf
-xP
+zg
 Hf
 Hf
 Hf
@@ -65130,7 +65150,7 @@ xP
 Zm
 xP
 Hf
-Hf
+WZ
 Hf
 xP
 hc
@@ -65259,7 +65279,7 @@ Hf
 xP
 Hf
 Hf
-Hf
+WZ
 Hf
 xP
 tn
@@ -68659,7 +68679,7 @@ xP
 Hf
 Hf
 Hf
-Hf
+WZ
 Hf
 Hf
 hc
@@ -69022,7 +69042,7 @@ tn
 tn
 tn
 tn
-xP
+zg
 xP
 tn
 tn
@@ -73687,7 +73707,7 @@ Hf
 Hf
 Hf
 Hf
-Hf
+WZ
 Hf
 Hf
 tn
@@ -76204,7 +76224,7 @@ hc
 xP
 xP
 Hf
-Hf
+WZ
 Hf
 Hf
 Hf
@@ -78031,7 +78051,7 @@ tn
 hc
 xP
 Hf
-Hf
+WZ
 Hf
 Hf
 xP
@@ -80580,7 +80600,7 @@ xP
 xP
 xP
 QI
-QI
+jR
 QI
 Xp
 xP
@@ -90589,7 +90609,7 @@ xP
 xP
 Xp
 QI
-QI
+jR
 EL
 tn
 Xp
@@ -94303,7 +94323,7 @@ ej
 xK
 SL
 xK
-SL
+hE
 SL
 SL
 ej
@@ -99905,7 +99925,7 @@ Hf
 tn
 tn
 Hf
-Hf
+WZ
 Hf
 Hf
 Hf

--- a/_maps/map_files/temperance/kingsrow.dmm
+++ b/_maps/map_files/temperance/kingsrow.dmm
@@ -1234,9 +1234,9 @@
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
 "hi" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/structure/fluff/statue/femalestatue2,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/beach/forest/south)
+/area/rogue/outdoors)
 "hj" = (
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1528,10 +1528,6 @@
 "jm" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue)
-"jn" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/beach/forest/south)
 "jq" = (
 /obj/structure/fluff/railing/corner,
 /obj/structure/flora/roguegrass,
@@ -6159,10 +6155,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
-"OV" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors)
 "OW" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -65076,7 +65068,7 @@ xP
 xP
 Hf
 Hf
-hi
+xP
 Hf
 Hf
 Hf
@@ -69037,7 +69029,7 @@ tn
 tn
 tn
 tn
-hi
+xP
 xP
 tn
 tn
@@ -80595,7 +80587,7 @@ xP
 xP
 xP
 QI
-jn
+QI
 QI
 Xp
 xP
@@ -90604,7 +90596,7 @@ xP
 xP
 Xp
 QI
-jn
+QI
 EL
 tn
 Xp
@@ -94318,7 +94310,7 @@ ej
 xK
 SL
 xK
-OV
+SL
 SL
 SL
 ej
@@ -95449,14 +95441,14 @@ wb
 ej
 wK
 ej
-ej
-ej
+vF
+Ka
 wK
 ej
 ej
-wK
-ej
-wK
+Ka
+Ka
+vF
 wK
 SL
 SL
@@ -95679,11 +95671,11 @@ ej
 RH
 RH
 ej
+RH
 ej
-ej
-ej
-ej
-ej
+RH
+RH
+RH
 ej
 ej
 wK
@@ -95904,13 +95896,13 @@ wK
 fZ
 wK
 RH
-wK
+hi
 ej
 ej
 ej
 ej
 RH
-RH
+wb
 ej
 wK
 wK
@@ -96357,7 +96349,7 @@ wb
 fZ
 OP
 ej
-ej
+wb
 ej
 wK
 ej
@@ -96584,12 +96576,12 @@ wb
 ej
 wK
 ej
-wK
+vF
 wK
 wK
 ej
 ej
-ej
+RH
 wK
 ej
 ej

--- a/_maps/map_files/temperance/kingsrow.dmm
+++ b/_maps/map_files/temperance/kingsrow.dmm
@@ -1163,6 +1163,10 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/town)
+"gv" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "gz" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/medicines,
@@ -1313,10 +1317,6 @@
 "hA" = (
 /obj/structure/mineral_door/wood/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors)
-"hE" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
 "hF" = (
 /obj/effect/mine/explosive,
@@ -1481,6 +1481,10 @@
 "iU" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/beach/forest/south)
+"iV" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/beach/forest/south)
 "iW" = (
 /obj/effect/decal/cleanable/blood/drip{
 	icon_state = "floor6"
@@ -1577,10 +1581,6 @@
 "jO" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"jR" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/beach/forest/south)
 "jV" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -1932,6 +1932,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/town)
+"mv" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/beach/forest/south)
 "mx" = (
 /obj/item/rogueweapon/pick/militia/steel,
 /obj/structure/rack/rogue,
@@ -3762,10 +3766,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
-"zg" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/beach/forest/south)
 "zk" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -3894,6 +3894,10 @@
 	},
 /turf/closed/wall/mineral/rogue/kingsrow/end,
 /area/rogue/indoors/shelter/town)
+"Ad" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest/south)
 "Af" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -4188,10 +4192,6 @@
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
-"BY" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "Ca" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/fluff/railing/border/west,
@@ -4302,6 +4302,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
+"CS" = (
+/obj/machinery/light/roguestreet/midlamp,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "CU" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/rogue/cobble,
@@ -4970,6 +4974,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/town)
+"Hp" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors)
 "Hx" = (
 /obj/structure/table/wood/perserdunsmall/woodtablefine,
 /obj/effect/decal/carpet/square{
@@ -7397,10 +7405,6 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/town)
-"WZ" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/beach/forest/south)
 "Xa" = (
 /obj/structure/fluff/pillow/magenta{
 	pixel_x = 2;
@@ -16871,7 +16875,7 @@ md
 TY
 TY
 TY
-BY
+gv
 aX
 TY
 aX
@@ -62322,7 +62326,7 @@ xP
 Hf
 tn
 tn
-WZ
+iV
 Hf
 Hf
 Hf
@@ -65081,7 +65085,7 @@ xP
 xP
 Hf
 Hf
-zg
+Ad
 Hf
 Hf
 Hf
@@ -65150,7 +65154,7 @@ xP
 Zm
 xP
 Hf
-WZ
+iV
 Hf
 xP
 hc
@@ -65279,7 +65283,7 @@ Hf
 xP
 Hf
 Hf
-WZ
+iV
 Hf
 xP
 tn
@@ -68679,7 +68683,7 @@ xP
 Hf
 Hf
 Hf
-WZ
+iV
 Hf
 Hf
 hc
@@ -69042,7 +69046,7 @@ tn
 tn
 tn
 tn
-zg
+Ad
 xP
 tn
 tn
@@ -73707,7 +73711,7 @@ Hf
 Hf
 Hf
 Hf
-WZ
+iV
 Hf
 Hf
 tn
@@ -75414,10 +75418,10 @@ Ot
 Ot
 Ot
 Mo
-Cr
+CS
 jO
 jO
-Cr
+CS
 Mo
 Ot
 Ot
@@ -76224,7 +76228,7 @@ hc
 xP
 xP
 Hf
-WZ
+iV
 Hf
 Hf
 Hf
@@ -78051,7 +78055,7 @@ tn
 hc
 xP
 Hf
-WZ
+iV
 Hf
 Hf
 xP
@@ -80600,7 +80604,7 @@ xP
 xP
 xP
 QI
-jR
+mv
 QI
 Xp
 xP
@@ -90609,7 +90613,7 @@ xP
 xP
 Xp
 QI
-jR
+mv
 EL
 tn
 Xp
@@ -94323,7 +94327,7 @@ ej
 xK
 SL
 xK
-hE
+Hp
 SL
 SL
 ej
@@ -99925,7 +99929,7 @@ Hf
 tn
 tn
 Hf
-WZ
+iV
 Hf
 Hf
 Hf

--- a/_maps/map_files/temperance/kingsrow.dmm
+++ b/_maps/map_files/temperance/kingsrow.dmm
@@ -1163,10 +1163,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/town)
-"gv" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "gz" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/medicines,
@@ -1238,9 +1234,9 @@
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
 "hi" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/shelter/town)
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/beach/forest/south)
 "hj" = (
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1481,10 +1477,6 @@
 "iU" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/beach/forest/south)
-"iV" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/beach/forest/south)
 "iW" = (
 /obj/effect/decal/cleanable/blood/drip{
 	icon_state = "floor6"
@@ -1536,6 +1528,10 @@
 "jm" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue)
+"jn" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/beach/forest/south)
 "jq" = (
 /obj/structure/fluff/railing/corner,
 /obj/structure/flora/roguegrass,
@@ -1932,10 +1928,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/town)
-"mv" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/beach/forest/south)
 "mx" = (
 /obj/item/rogueweapon/pick/militia/steel,
 /obj/structure/rack/rogue,
@@ -2001,6 +1993,10 @@
 	},
 /turf/open/floor/rogue/blocks/flipped,
 /area/rogue/indoors/shelter/town)
+"na" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/beach/forest/south)
 "nf" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/dirt/road,
@@ -2589,6 +2585,10 @@
 /obj/structure/mineral_door/wood/violet,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/shelter/town)
+"qT" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "qU" = (
 /turf/closed/mineral/rogue/copper,
 /area/rogue/under/cave)
@@ -3894,10 +3894,6 @@
 	},
 /turf/closed/wall/mineral/rogue/kingsrow/end,
 /area/rogue/indoors/shelter/town)
-"Ad" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/beach/forest/south)
 "Af" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -4302,10 +4298,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
-"CS" = (
-/obj/machinery/light/roguestreet/midlamp,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
 "CU" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/rogue/cobble,
@@ -4409,6 +4401,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/south)
+"Dy" = (
+/obj/machinery/light/roguestreet/midlamp,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "DB" = (
 /obj/item/rope/chain,
 /turf/open/floor/rogue/naturalstone,
@@ -4974,10 +4970,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/town)
-"Hp" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors)
 "Hx" = (
 /obj/structure/table/wood/perserdunsmall/woodtablefine,
 /obj/effect/decal/carpet/square{
@@ -5791,12 +5783,6 @@
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "garrison"
 	},
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "garrison"
-	},
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "garrison"
-	},
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
 "MB" = (
@@ -5962,6 +5948,7 @@
 /area/rogue/outdoors/town)
 "ND" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/blocks/flipped,
 /area/rogue/indoors/shelter/town)
 "NE" = (
@@ -6172,6 +6159,10 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
+"OV" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors)
 "OW" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -16875,7 +16866,7 @@ md
 TY
 TY
 TY
-gv
+qT
 aX
 TY
 aX
@@ -23919,7 +23910,7 @@ jm
 jm
 uf
 hL
-hi
+Vy
 ND
 mZ
 Xa
@@ -62326,7 +62317,7 @@ xP
 Hf
 tn
 tn
-iV
+na
 Hf
 Hf
 Hf
@@ -65085,7 +65076,7 @@ xP
 xP
 Hf
 Hf
-Ad
+hi
 Hf
 Hf
 Hf
@@ -65154,7 +65145,7 @@ xP
 Zm
 xP
 Hf
-iV
+na
 Hf
 xP
 hc
@@ -65283,7 +65274,7 @@ Hf
 xP
 Hf
 Hf
-iV
+na
 Hf
 xP
 tn
@@ -68683,7 +68674,7 @@ xP
 Hf
 Hf
 Hf
-iV
+na
 Hf
 Hf
 hc
@@ -69046,7 +69037,7 @@ tn
 tn
 tn
 tn
-Ad
+hi
 xP
 tn
 tn
@@ -73711,7 +73702,7 @@ Hf
 Hf
 Hf
 Hf
-iV
+na
 Hf
 Hf
 tn
@@ -75418,10 +75409,10 @@ Ot
 Ot
 Ot
 Mo
-CS
+Dy
 jO
 jO
-CS
+Dy
 Mo
 Ot
 Ot
@@ -76228,7 +76219,7 @@ hc
 xP
 xP
 Hf
-iV
+na
 Hf
 Hf
 Hf
@@ -78055,7 +78046,7 @@ tn
 hc
 xP
 Hf
-iV
+na
 Hf
 Hf
 xP
@@ -80604,7 +80595,7 @@ xP
 xP
 xP
 QI
-mv
+jn
 QI
 Xp
 xP
@@ -90613,7 +90604,7 @@ xP
 xP
 Xp
 QI
-mv
+jn
 EL
 tn
 Xp
@@ -94327,7 +94318,7 @@ ej
 xK
 SL
 xK
-Hp
+OV
 SL
 SL
 ej
@@ -99929,7 +99920,7 @@ Hf
 tn
 tn
 Hf
-iV
+na
 Hf
 Hf
 Hf

--- a/_maps/map_files/temperance/perserdun.dmm
+++ b/_maps/map_files/temperance/perserdun.dmm
@@ -1841,6 +1841,10 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/perserdun)
+"EB" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/perserdun)
 "EC" = (
 /obj/structure/fluff/railing/sandbag{
 	dir = 1
@@ -21974,7 +21978,7 @@ ML
 wB
 ML
 ML
-ML
+EB
 ML
 TK
 TK
@@ -22990,7 +22994,7 @@ ML
 TK
 ML
 ML
-ML
+EB
 ML
 ML
 ML
@@ -24925,7 +24929,7 @@ ML
 ML
 ML
 ML
-ML
+EB
 TK
 TK
 ML
@@ -26180,7 +26184,7 @@ ML
 ML
 ML
 ML
-ML
+EB
 TK
 ML
 ML
@@ -29476,7 +29480,7 @@ ML
 ML
 ML
 ML
-ML
+EB
 ML
 ML
 ML
@@ -30677,7 +30681,7 @@ ML
 qs
 ML
 ML
-ML
+EB
 ML
 ML
 ML
@@ -30790,7 +30794,7 @@ TK
 ML
 ML
 ML
-ML
+EB
 ML
 ML
 ML
@@ -31985,7 +31989,7 @@ ML
 ML
 ML
 ML
-ML
+EB
 ML
 TK
 ML
@@ -32767,7 +32771,7 @@ ML
 ML
 ML
 ML
-ML
+EB
 ML
 ML
 qs

--- a/_maps/map_files/temperance/risvon.dmm
+++ b/_maps/map_files/temperance/risvon.dmm
@@ -2984,6 +2984,10 @@
 	},
 /turf/open/floor/rogue/risvon,
 /area/rogue/indoors/risvonbase)
+"yT" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/risvon)
 "yU" = (
 /obj/structure/mineral_door/bars,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -6315,6 +6319,10 @@
 /obj/structure/chair/bench/couch,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/town/sargoth)
+"YC" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/risvon)
 "YL" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/church,
@@ -9821,7 +9829,7 @@ cn
 cn
 Ba
 Ba
-cn
+yT
 cn
 cn
 Ba
@@ -15166,7 +15174,7 @@ Ba
 Ba
 Ba
 Ba
-Ba
+YC
 Ba
 Ba
 Ba
@@ -15280,7 +15288,7 @@ wA
 Ba
 Ba
 Ba
-Ba
+YC
 Ba
 Ba
 Ba
@@ -20749,7 +20757,7 @@ cn
 cn
 cn
 cn
-cn
+yT
 cn
 cn
 cn


### PR DESCRIPTION
## About The Pull Request

- Adds Rats and mouse corpses to the map in various spots as both a pest and a potential source of nutrition.
- Removes a clock in the mages guild that was behaving strangely and replaces it with a statue for loadout aquisition purposes
- removes several doors on in the hierarch office that were strangely stacked on top of each other. 
- adds two lights in the long dark hallway between the far travel and kings row town proper. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
https://imgur.com/a/arp0oRm
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Adds more oppurtunity for risvonians and pererdunians to find food, Makes it so trying to find far travel in kings row is less annoying, and no more clock sounds on the server main menu. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
