### PR TITLE
Adds an Alchemy table to the morticians office. 

### DIFF
--- a/_maps/map_files/temperance/kingsrow.dmm
+++ b/_maps/map_files/temperance/kingsrow.dmm
@@ -2059,6 +2059,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/brown,
 /area/rogue/indoors/shelter/town)
+"nR" = (
+/obj/machinery/light/rogue/cauldron,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/shelter/town)
 "nW" = (
 /obj/structure/table/wood/large_table/north_east{
 	dir = 1
@@ -2254,6 +2258,10 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/weak,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/town)
+"pd" = (
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/shelter/town)
 "pe" = (
 /obj/structure/chair/bench/couchablack/r,
@@ -3596,6 +3604,10 @@
 "xD" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/brown,
+/area/rogue/indoors/shelter/town)
+"xG" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/shelter/town)
 "xH" = (
 /obj/structure/chair/wood/rogue/generic1{
@@ -71337,9 +71349,9 @@ uf
 lr
 VB
 uf
-Oe
+aT
 AH
-zQ
+Oe
 uf
 nz
 nz
@@ -74281,7 +74293,7 @@ Ot
 Ot
 Ot
 uf
-LO
+xG
 is
 pT
 uf
@@ -75190,8 +75202,8 @@ Ot
 Ot
 uf
 YB
-vH
-vH
+pd
+nR
 uf
 jr
 jr


### PR DESCRIPTION
Adds an alchemy bench and cauldron in the morticians office

## About The Pull Request
Adds an alchemy bench and cauldron in the morticians office
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gives town the ability to make health potions. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
