### PR TITLE
Add round+sharp snouts to Black Beasts.

### DIFF
--- a/code/modules/client/customizer/customizers/organ/snout.dm
+++ b/code/modules/client/customizer/customizers/organ/snout.dm
@@ -144,10 +144,10 @@
 		/datum/sprite_accessory/snout/hjackal,
 		/datum/sprite_accessory/snout/hspots,
 		/datum/sprite_accessory/snout/hhorse,
-		/datum/sprite_accessory/snout/sharp
-		/datum/sprite_accessory/snout/sharplight
-		/datum/sprite_accessory/snout/round
-		/datum/sprite_accessory/snout/roundlight
+		/datum/sprite_accessory/snout/sharp,
+		/datum/sprite_accessory/snout/sharplight,
+		/datum/sprite_accessory/snout/round,
+		/datum/sprite_accessory/snout/roundlight,
 		)
 
 /datum/customizer/organ/snout/akula

--- a/code/modules/client/customizer/customizers/organ/snout.dm
+++ b/code/modules/client/customizer/customizers/organ/snout.dm
@@ -144,6 +144,10 @@
 		/datum/sprite_accessory/snout/hjackal,
 		/datum/sprite_accessory/snout/hspots,
 		/datum/sprite_accessory/snout/hhorse,
+		/datum/sprite_accessory/snout/sharp
+		/datum/sprite_accessory/snout/sharplight
+		/datum/sprite_accessory/snout/round
+		/datum/sprite_accessory/snout/roundlight
 		)
 
 /datum/customizer/organ/snout/akula


### PR DESCRIPTION
## About The Pull Request

Simply adds the datums for round and sharp snouts back to the customizer snout accessory list for Black Beasts.
The datums were still in the code so it was easy to add them back.

## Testing Evidence

<img width="1113" height="860" alt="Screenshot 2026-03-28 163940" src="https://github.com/user-attachments/assets/e5da2453-b65c-4c0a-abbb-8420c0ba1a81" />

## Why It's Good For The Game

We already have a bunch of snouts for dogs, cats, and other animals that fit the Black Beast's lore. Round and sharp snouts are just a less specific, generic version of those existing snouts. They also encompass other animals that are part of the Zodiac table mentioned in the Black Beast lore snippet, like rabbits.

I didn't add lizard tails as part of this PR because I don't know if they are intended to be part of Black Beasts yet. I do know that round snouts apply to way more than just lizards, though.
